### PR TITLE
(fix) Update modal URLs for deployed version

### DIFF
--- a/src/app/addins/portal-action/portal-action.component.ts
+++ b/src/app/addins/portal-action/portal-action.component.ts
@@ -29,7 +29,12 @@ export class PortalActionComponent implements OnInit {
         switchMap(() => this.getUserIdentityToken())
       ).subscribe((userIdentityToken) => {
 
-      const addinModal = window.location.origin + '/addins/action/register';
+      let addinModal = window.location.origin + '/addins/action/register';
+
+      // the deployed url doesn't work the same as the localhost. This is a workaround.
+      if (addinModal.includes('github.io')) {
+        addinModal = window.location.origin + '/skyux-portal-addin-demo' + '/addins/action/register'
+      }
       this.addinClientService.showModal({ url: addinModal, context: { userIdentity: userIdentityToken }});
     });
   }

--- a/src/app/addins/settings/settings.component.ts
+++ b/src/app/addins/settings/settings.component.ts
@@ -22,8 +22,14 @@ export class SettingsComponent implements OnInit {
 
   public actionClicked(action: 'edit' | 'disable' | 'enable'): void {
     if (action === 'edit') {
-      const addinModal = window.location.origin + '/addins/settings/edit';
-      this.addinClientService.showModal({ url: addinModal })
+      let addinModal = window.location.origin + '/addins/settings/edit';
+
+      // the deployed url doesn't work the same as the localhost. This is a workaround.
+      if (addinModal.includes('github.io')) {
+        addinModal = window.location.origin + '/skyux-portal-addin-demo' + '/addins/settings/edit';
+      }
+
+      this.addinClientService.showModal({ url: addinModal });
     }
 
     if (action === 'disable') {


### PR DESCRIPTION
The deployed version adds a subpath to the URL so we can't just use the origin to open the modals. This does a workaround for that instead of doing something smart